### PR TITLE
Added support for extra options in upstart script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 spec/fixtures
+vendor

--- a/templates/vault.upstart.erb
+++ b/templates/vault.upstart.erb
@@ -8,10 +8,10 @@ respawn limit 10 10
 kill timeout 10
 
 env GOMAXPROCS=<%= scope.lookupvar("::processorcount") %>
-env CONFFILE='<%= scope.lookupvar('vault::config_dir') %>/config.json'
+env CONFIG='<%= scope.lookupvar('vault::config_dir') %>/config.json'
 
 script
     # read settings like GOMAXPROCS from "/etc/default/vault", if available.
     [ -e "/etc/default/vault" ] && . "/etc/default/vault"
-    exec vault server -config $CONFFILE
+    exec vault server -config "$CONFIG" <%= scope.lookupvar('vault::extra_options').shelljoin %>
 end script


### PR DESCRIPTION
Added support for `vault::extra_options` in upstart config file. This made the test that was already there for it and failing (and confusing me because I couldn't work out how I'd broken it or how it even passed in the first place) pass.

I also added `vendor/` to `.gitignore` seeing as it gets created in the normal testing workflow.