### PR TITLE
Require shellwords in vault.upstart.erb

### DIFF
--- a/templates/vault.upstart.erb
+++ b/templates/vault.upstart.erb
@@ -1,3 +1,4 @@
+<% require 'shellwords' -%>
 # Vault Server (Upstart unit)
 description "Vault Server"
 start on (local-filesystems and net-device-up IFACE!=lo)


### PR DESCRIPTION
`Shellwords` [monkey patches](https://github.com/ruby/ruby/blob/96db72ce38b27799dd8e80ca00696e41234db6ba/lib/shellwords.rb#L220) `shelljoin` into `Array`. If `vault.upstart.erb` doesn't require it explicitly, the ERB output is non-deterministic. F.e.: our Vault config can flap between these two states depending on "what came before" during Ruby's module import process:

```
-    exec vault server -config "$CONFIG" []
+    exec vault server -config "$CONFIG"
```

```
-    exec vault server -config "$CONFIG"
+    exec vault server -config "$CONFIG" []
```

This PR addresses the problem, internal ticket is OPS-13266 .