### PR TITLE
Basic acceptance tests (PEAUTO-330)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 spec/fixtures
 vendor
+.*.swp
+/log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,20 @@
 ---
 language: ruby
-bundler_args: --without development
-before_install: rm Gemfile.lock || true
-rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-script: bundle exec rake test
-env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.1.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.0"
-  - PUPPET_VERSION="~> 3.5.0"
-  - PUPPET_VERSION="~> 3.7.0"
-  - PUPPET_VERSION="~> 3.7.4" FUTURE_PARSER=yes
+sudo: false
+cache: bundler
+bundler_args: --without system_tests
+script: "bundle exec rake test"
 matrix:
-  exclude:
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
+  fast_finish: true
+  include:
   - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
+    env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.1.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.1.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.4.0"
+    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+  - rvm: 2.1.6
+    env: PUPPET_GEM_VERSION="~> 4.0"
+  - rvm: 2.1.10
+    sudo: required
+    services: docker
+    bundler_args:
+    script: bundle exec rake beaker

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,19 @@
-source "http://rubygems.org"
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-group :test do
-  gem 'rake', '< 11.0'
-  gem "puppet-blacksmith"
-  gem "puppet", '~> 3.7.0'
-  gem "puppet-lint"
-  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
-  gem "puppet-syntax"
-  gem "puppetlabs_spec_helper"
-  gem "hiera-puppet-helper"
+group :tests do
+  gem 'puppetlabs_spec_helper'
+  gem 'hiera-puppet-helper'
 end
 
-group :development do
-  gem 'json'
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-docker'
+  gem 'beaker-rspec'
+  gem 'beaker-puppet_install_helper'
+end
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+    gem 'puppet', puppetversion, :require => false
+else
+    gem 'puppet', '~> 4.5.0', :require => false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,80 +1,156 @@
-GIT
-  remote: https://github.com/rodjek/rspec-puppet.git
-  revision: 0528059f0a6cf0a34bf7682a4fb4f301913ca182
-  specs:
-    rspec-puppet (2.6.13)
-      rspec
-
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
+    ansi (1.5.0)
+    ast (2.4.0)
+    beaker (4.5.0)
+      beaker-hostgenerator
+      hocon (~> 1.0)
+      in-parallel (~> 0.1)
+      inifile (~> 3.0)
+      minitar (~> 0.6)
+      minitest (~> 5.4)
+      net-scp (~> 1.2)
+      net-ssh (~> 4.0)
+      open_uri_redirections (~> 0.2.1)
+      pry-byebug (~> 3.4.2)
+      rb-readline (~> 0.5.3)
+      rsync (~> 1.0.9)
+      stringify-hash (~> 0.0)
+      thor (~> 0.19)
+    beaker-abs (0.5.0)
+    beaker-answers (0.25.0)
+      hocon (~> 1.0)
+      require_all (~> 1.3.2)
+      stringify-hash (~> 0.0.0)
+    beaker-docker (0.5.2)
+      docker-api
+      stringify-hash (~> 0.0.0)
+    beaker-hostgenerator (1.1.25)
+      deep_merge (~> 1.0)
+      stringify-hash (~> 0.0.0)
+    beaker-pe (2.0.6)
+      beaker (~> 4.0)
+      beaker-abs
+      beaker-answers (~> 0.0)
+      beaker-puppet (~> 1.0)
+      beaker-vmpooler (~> 1.0)
+      stringify-hash (~> 0.0.0)
+    beaker-puppet (1.16.0)
+      beaker (~> 4.1)
+      in-parallel (~> 0.1)
+      oga
+      stringify-hash (~> 0.0.0)
+    beaker-puppet_install_helper (0.9.7)
+      beaker (~> 4.0)
+      beaker-pe (~> 2.0)
+    beaker-rspec (6.2.4)
+      beaker (> 3.0)
+      rspec (~> 3.0)
+      serverspec (~> 2)
+      specinfra (~> 2)
+    beaker-vmpooler (1.3.1)
+      stringify-hash (~> 0.0.0)
+    byebug (9.0.6)
+    coderay (1.1.2)
+    deep_merge (1.2.1)
     diff-lcs (1.3)
-    domain_name (0.5.20180417)
-      unf (>= 0.0.5, < 1.0.0)
+    docker-api (1.34.2)
+      excon (>= 0.47.0)
+      multi_json
+    excon (0.62.0)
     facter (2.5.1)
-    hiera (1.3.4)
-      json_pure
+    hiera (3.5.0)
     hiera-puppet-helper (1.0.1)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
-    json (2.1.0)
+    hocon (1.2.5)
+    in-parallel (0.1.17)
+    inifile (3.0.0)
     json_pure (2.1.0)
     metaclass (0.0.4)
-    mime-types (3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
-    mocha (1.5.0)
+    method_source (0.9.2)
+    minitar (0.8)
+    minitest (5.11.3)
+    mocha (1.8.0)
       metaclass (~> 0.0.1)
-    netrc (0.11.0)
-    puppet (3.7.5)
-      facter (> 1.6, < 3)
-      hiera (~> 1.0)
+    multi_json (1.13.1)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (4.2.0)
+    net-telnet (0.1.1)
+    oga (2.15)
+      ast
+      ruby-ll (~> 2.1)
+    open_uri_redirections (0.2.1)
+    pathspec (0.2.1)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.4.3)
+      byebug (>= 9.0, < 9.1)
+      pry (~> 0.10)
+    puppet (4.5.3)
+      facter (> 2.0, < 4)
+      hiera (>= 2.0, < 4)
       json_pure
-    puppet-blacksmith (4.1.2)
-      rest-client (~> 2.0)
-    puppet-lint (2.3.5)
-    puppet-syntax (2.4.1)
+    puppet-lint (2.3.6)
+    puppet-syntax (2.4.3)
       rake
-    puppetlabs_spec_helper (2.9.1)
+    puppetlabs_spec_helper (2.13.1)
       mocha (~> 1.0)
+      pathspec (~> 0.2.1)
       puppet-lint (~> 2.0)
       puppet-syntax (~> 2.0)
       rspec-puppet (~> 2.0)
-    rake (10.5.0)
-    rest-client (2.0.2)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rake (12.3.2)
+    rb-readline (0.5.5)
+    require_all (1.3.3)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.5)
+      rspec-support (~> 3.8.0)
+    rspec-puppet (2.7.3)
+      rspec
+    rspec-support (3.8.0)
+    rsync (1.0.9)
+    ruby-ll (2.1.2)
+      ansi
+      ast
+    serverspec (2.41.3)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.72)
+    sfl (2.3)
+    specinfra (2.76.9)
+      net-scp
+      net-ssh (>= 2.7)
+      net-telnet (= 0.1.1)
+      sfl
+    stringify-hash (0.0.2)
+    thor (0.20.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  beaker
+  beaker-docker
+  beaker-puppet_install_helper
+  beaker-rspec
   hiera-puppet-helper
-  json
-  puppet (~> 3.7.0)
-  puppet-blacksmith
-  puppet-lint
-  puppet-syntax
+  puppet (~> 4.5.0)
   puppetlabs_spec_helper
-  rake (< 11.0)
-  rspec-puppet!
 
 BUNDLED WITH
-   1.16.2
+   1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -11,22 +11,13 @@ begin
 rescue LoadError
 end
 
-PuppetLint.configuration.send("disable_80chars")
 PuppetLint.configuration.log_format = "%{path}:%{line}:%{check}:%{KIND}:%{message}"
-PuppetLint.configuration.fail_on_warnings = true
-
-# Forsake support for Puppet 2.6.2 for the benefit of cleaner code.
-# http://puppet-lint.com/checks/class_parameter_defaults/
-PuppetLint.configuration.send('disable_class_parameter_defaults')
-# http://puppet-lint.com/checks/class_inherits_from_params_class/
-PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 
 exclude_paths = [
   "pkg/**/*",
   "vendor/**/*",
   "spec/**/*",
 ]
-PuppetLint.configuration.ignore_paths = exclude_paths
 PuppetSyntax.exclude_paths = exclude_paths
 
 desc "Run syntax, lint, and spec tests."

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
 
+
 # These two gems aren't always present, for instance
 # on Travis with --without development
 begin
@@ -27,11 +28,6 @@ exclude_paths = [
 ]
 PuppetLint.configuration.ignore_paths = exclude_paths
 PuppetSyntax.exclude_paths = exclude_paths
-
-desc "Run acceptance tests"
-RSpec::Core::RakeTask.new(:acceptance) do |t|
-  t.pattern = 'spec/acceptance'
-end
 
 desc "Run syntax, lint, and spec tests."
 task :test => [

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,1 @@
+ubuntu-14.04-docker.yaml

--- a/spec/acceptance/nodesets/ubuntu-14.04-docker.yaml
+++ b/spec/acceptance/nodesets/ubuntu-14.04-docker.yaml
@@ -1,0 +1,21 @@
+---
+HOSTS:
+  ubuntu1404-64-1:
+    masterless: true
+    docker_cmd:
+    - "/sbin/init"
+    image: ubuntu:14.04
+    platform: ubuntu-14.04-amd64
+    packaging_platform: ubuntu-14.04-amd64
+    docker_image_commands:
+    - cp /bin/true /sbin/agetty
+    - rm /usr/sbin/policy-rc.d
+    - rm /sbin/initctl; dpkg-divert --rename --remove /sbin/initctl
+    - apt-get install -y net-tools wget apt-transport-https
+    - locale-gen en_US.UTF-8
+    - echo LANG=en_US.UTF-8 > /etc/default/locale
+    hypervisor: docker
+    docker_preserve_image: true
+CONFIG:
+  masterless: true
+  type: foss

--- a/spec/acceptance/vault_spec.rb
+++ b/spec/acceptance/vault_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper_acceptance'
+
+describe 'vault' do
+  it 'should install the right version' do
+    apply_manifest('include vault', :catch_failures => true)
+    expect(file('/usr/local/bin/vault')).to exist
+    expect(file('/etc/vault')).to_not exist
+    expect(command('/usr/local/bin/vault version').stdout).to match(/Vault v0\.6\.0/)
+  end
+
+  it 'should start the service' do
+    # Sometimes Vault expects strings instead of booleans, hence the doubly quoted '"true'" below
+    manifest = <<-EOM
+    file {'/etc/vault':
+      ensure => directory
+    }
+    -> class {'vault':
+      config_hash => {'disable_mlock' => true},
+      backend => {'file' => {'path' => '/tmp/data.vault'}},
+      listener => {'tcp' => {'address' => '127.0.0.1:18200', 'tls_disable' => '"true"'}},
+    }
+    EOM
+    apply_manifest(manifest, :catch_failures => true)
+    expect(service('vault')).to be_running
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -5,8 +5,10 @@ describe 'vault' do
     c.default_facts = {
       :architecture    => 'x86_64',
       :operatingsystem => 'Ubuntu',
+      :osfamily        => 'Debian',
       :lsbdistrelease  => '10.04',
       :kernel          => 'Linux',
+      :staging_http_get => 'curl'
     }
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,5 +15,4 @@ RSpec.configure do |c|
   c.before(:each) do
     Puppet::Indirector::Hiera.stub(:hiera => hiera_stub)
   end
-
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,20 @@
+require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
+
+run_puppet_install_helper
+
+RSpec.configure do |c|
+  module_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    hosts.each do |host|
+      puppet_module_install(:source => module_root, :module_name => 'vault')
+      on host, puppet('module install puppetlabs-stdlib'), {:acceptable_exit_codes => [0]}
+      on host, puppet('module install puppet/staging'), {:acceptable_exit_codes => [0]}
+    end
+  end
+end


### PR DESCRIPTION
- Basic Beaker tests. They only target `ubuntu:14.04` for the time being. I'm going to add Bionic next (which is what tricked me into giving some tlc to this Puppet module).
- Got rid of redundant `puppet-lint` settings that `puppetlabs_spec_helper` [overrides anyway](https://github.com/puppetlabs/puppetlabs_spec_helper/blob/master/lib/puppetlabs_spec_helper/rake_tasks.rb#L174) .
- Asked @bobtfish to enable Travis and made some changes to the config. Let me know if you think we need more coverage between Ruby/Puppet versions.