### PR TITLE
Adding optional OOM score for systemd & upstart

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,10 @@
 #   Config file name, relative to `$config_dir`.
 #   If undef (default), Vault will load all `*.json` and `*.hcl` files it finds in `$config_dir`.
 #   This parameter is only available on systemd distros.
+# 
+# [*oom_score*]
+#   Adjusts the oom score to a user set value between -1000 and 1000. 
+#   Ideal to use if you have memory hungry services running alongside vault
 #
 class vault (
   $backend            = undef,
@@ -71,6 +75,7 @@ class vault (
   $service_ensure     = 'running',
   $manage_service     = true,
   $init_style         = $vault::params::init_style,
+  $oom_score          = undef,
 ) inherits vault::params {
 
   $real_download_url    = pick($download_url, "${download_url_base}${version}/${package_name}_${version}_${os}_${arch}.${download_extension}")

--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -18,7 +18,8 @@ end %> <%= scope.lookupvar('vault::extra_options').shelljoin %>
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure
-RestartSec=42s
+RestartSec=42s <% if !scope.lookupvar('vault::oom_score').nil? or !scope.lookupvar('vault::oom_score').to_s == 'undef'%>
+OOMScoreAdjust=<%= scope.lookupvar('vault::oom_score') %> <% end %>
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -22,5 +22,6 @@ RestartSec=42s
 <% if !scope.lookupvar('vault::oom_score').nil? or !scope.lookupvar('vault::oom_score').to_s == 'undef' -%>
 OOMScoreAdjust=<%= scope.lookupvar('vault::oom_score') %>
 <% end -%>
+
 [Install]
 WantedBy=multi-user.target

--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -18,8 +18,9 @@ end %> <%= scope.lookupvar('vault::extra_options').shelljoin %>
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure
-RestartSec=42s <% if !scope.lookupvar('vault::oom_score').nil? or !scope.lookupvar('vault::oom_score').to_s == 'undef'%>
-OOMScoreAdjust=<%= scope.lookupvar('vault::oom_score') %> <% end %>
-
+RestartSec=42s
+<% if !scope.lookupvar('vault::oom_score').nil? or !scope.lookupvar('vault::oom_score').to_s == 'undef' -%>
+OOMScoreAdjust=<%= scope.lookupvar('vault::oom_score') %>
+<% end -%>
 [Install]
 WantedBy=multi-user.target

--- a/templates/vault.upstart.erb
+++ b/templates/vault.upstart.erb
@@ -7,6 +7,9 @@ stop on runlevel [06]
 respawn
 respawn limit 10 10
 kill timeout 10
+<% if !scope.lookupvar('vault::oom_score').nil? or !scope.lookupvar('vault::oom_score').to_s == 'undef'%>
+oom score <%= scope.lookupvar('vault::oom_score') %>
+<% end -%>
 
 env GOMAXPROCS=<%= scope.lookupvar("::processorcount") %>
 env CONFIG='<%= scope.lookupvar('vault::config_dir') %>/config.json'

--- a/templates/vault.upstart.erb
+++ b/templates/vault.upstart.erb
@@ -7,7 +7,7 @@ stop on runlevel [06]
 respawn
 respawn limit 10 10
 kill timeout 10
-<% if !scope.lookupvar('vault::oom_score').nil? or !scope.lookupvar('vault::oom_score').to_s == 'undef'%>
+<% if !scope.lookupvar('vault::oom_score').nil? or !scope.lookupvar('vault::oom_score').to_s == 'undef' -%>
 oom score <%= scope.lookupvar('vault::oom_score') %>
 <% end -%>
 


### PR DESCRIPTION
Adds an optional `oom_score` parameter which adjusts the service unit files (systemd & upstart) with `OOMScoreAdjust=<value>` and `oom score <value>` respectively.

This is being added as a failsafe to make sure vault isn't killed if another process on the same host is leaking memory. 

To use:

```
-> class { 'vault':
...
    oom_score => -500,
...
}
```