### PR TITLE
Replace legacy facts

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,32 +24,32 @@ class vault::params {
   $os = downcase($::kernel)
 
   if $::operatingsystem == 'Ubuntu' {
-    if versioncmp($::lsbdistrelease, '8.04') < 1 {
+    if versioncmp($facts['os']['distro']['release']['full'], '8.04') < 1 {
       $init_style = 'debian'
-    } elsif versioncmp($::lsbdistrelease, '14.04') < 1  {
+    } elsif versioncmp($facts['os']['distro']['release']['full'], '14.04') < 1  {
       $init_style = 'upstart'
     } else {  # Use systemd from Xenial (inclusive) on
       $init_style = 'systemd'
     }
-  } elsif $::operatingsystem =~ /Scientific|CentOS|RedHat|OracleLinux/ {
-    if versioncmp($::operatingsystemrelease, '7.0') < 0 {
+  } elsif $facts['os']['name'] =~ /Scientific|CentOS|RedHat|OracleLinux/ {
+    if versioncmp($facts['os']['release']['full'], '7.0') < 0 {
       $init_style = 'sysv'
     } else {
       $init_style  = 'systemd'
     }
-  } elsif $::operatingsystem == 'Fedora' {
-    if versioncmp($::operatingsystemrelease, '12') < 0 {
+  } elsif $facts['os']['name'] == 'Fedora' {
+    if versioncmp($facts['os']['release']['full'], '12') < 0 {
       $init_style = 'sysv'
     } else {
       $init_style = 'systemd'
     }
-  } elsif $::operatingsystem == 'Debian' {
+  } elsif $facts['os']['name'] == 'Debian' {
     $init_style = 'debian'
-  } elsif $::operatingsystem == 'SLES' {
+  } elsif $facts['os']['name'] == 'SLES' {
     $init_style = 'sles'
-  } elsif $::operatingsystem == 'Darwin' {
+  } elsif $facts['os']['name'] == 'Darwin' {
     $init_style = 'launchd'
-  } elsif $::operatingsystem == 'Amazon' {
+  } elsif $facts['os']['name'] == 'Amazon' {
     $init_style = 'sysv'
   } else {
     $init_style = undef

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3,10 +3,21 @@ require 'spec_helper'
 describe 'vault' do
   RSpec.configure do |c|
     c.default_facts = {
+      :os              => {
+        'family' => 'Debain',
+        'name'   => 'Ubuntu',
+        'distro' => {
+          'release': {
+            'full': '10.04',
+            'major': '10.04',
+          }
+        },
+        'release': {
+          'full': '10.04',
+          'major': '10.04',
+        },
+      },
       :architecture    => 'x86_64',
-      :operatingsystem => 'Ubuntu',
-      :osfamily        => 'Debian',
-      :lsbdistrelease  => '10.04',
       :kernel          => 'Linux',
       :staging_http_get => 'curl'
     }
@@ -102,19 +113,64 @@ describe 'vault' do
   end
 
   context 'on Trusty (14.04)' do
-    let(:facts) {{ :lsbdistrelease => '14.04' }}
+    let(:facts) {{ 
+      :os              => {
+        'family' => 'Debain',
+        'name'   => 'Ubuntu',
+        'distro' => {
+          'release': {
+            'full': '14.04',
+            'major': '14.04',
+          }
+        },
+        'release': {
+          'full': '14.04',
+          'major': '14.04',
+        },
+      }
+    }}
     let(:params) {{ :backend => {}, :listener => {} }}
     it_behaves_like 'upstart'
   end
 
   context 'on Xenial (16.04)' do
-    let(:facts) {{ :lsbdistrelease => '16.04' }}
+    let(:facts) {{ 
+      :os              => {
+        'family' => 'Debain',
+        'name'   => 'Ubuntu',
+        'distro' => {
+          'release': {
+            'full': '16.04',
+            'major': '16.04',
+          }
+        },
+        'release': {
+          'full': '16.04',
+          'major': '16.04',
+        },
+      }
+    }}
     let(:params) {{ :backend => {}, :listener => {} }}
     it_behaves_like 'systemd'
   end
 
   context 'on Bionic (18.04)' do
-    let(:facts) {{ :lsbdistrelease => '18.04' }}
+    let(:facts) {{ 
+      :os              => {
+        'family' => 'Debain',
+        'name'   => 'Ubuntu',
+        'distro' => {
+          'release': {
+            'full': '18.04',
+            'major': '18.04',
+          }
+        },
+        'release': {
+          'full': '18.04',
+          'major': '18.04',
+        },
+      }
+    }}
     let(:params) {{ :backend => {}, :listener => {} }}
     it_behaves_like 'systemd'
   end


### PR DESCRIPTION
This module uses the old LSB facts which will no longer be available from Puppet 8. This uses the appropriate structured facts which are drop-in replacements.